### PR TITLE
Fix file extension of file generated from generateAWSConfig.sh

### DIFF
--- a/backend/Step7/generateAWSConfig.sh
+++ b/backend/Step7/generateAWSConfig.sh
@@ -7,7 +7,7 @@ idpool=$(aws cloudformation list-exports | jq '.Exports[] | select (.Name == "ST
 userpool=$(aws cloudformation list-exports | jq '.Exports[] | select (.Name == "STS-UserPoolId").Value' -r)
 appclient=$(aws cloudformation list-exports | jq '.Exports[] | select (.Name == "STS-AppClientId").Value' -r)
 
-file="./AWSConfig.json"
+file="./AWSConfig.js"
 rm $file
 echo "/* file generated from generateAWSConfig.sh */" >> $file
 


### PR DESCRIPTION
It was .json, correct is .js.

*Issue #, if available:*
#190

*Description of changes:*
Change file extension of AWSConfig.json to .js.
In the Readme, Backend Setup 10., the name is already correct:
> Copy the `AWSConfig.js` file you just created to `frontend/src/services/AWSConfig.js`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
